### PR TITLE
modify dropdown menu template to add resolve button

### DIFF
--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -41,6 +41,10 @@
 	<a component="topic/mark-unread-for-all" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-inbox text-secondary"></i> [[topic:thread-tools.markAsUnreadForAll]]</a>
 </li>
 
+<li>
+	<a component="topic/mark-resolve" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-inbox text-secondary"></i> Mark As Resolved </a>
+</li>
+
 <li class="dropdown-divider"></li>
 {{{ end }}}
 

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -40,6 +40,10 @@
 						<i class="fa fa-thumb-tack"></i>
 						<span>{{{ if !./pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}</span>
 					</span>
+					<span component="topic/resolved" class="badge border border-gray-300 text-body {{{ if (./scheduled || !./pinned) }}}hidden{{{ end }}}">
+						<i class="fa fa-check-circle"></i>
+						<span>{{{ if !./pinExpiry }}}Resolved{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}</span>
+					</span>
 					<span component="topic/locked" class="badge border border-gray-300 text-body {{{ if !./locked }}}hidden{{{ end }}}">
 						<i class="fa fa-lock"></i>
 						<span>[[topic:locked]]</span>

--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -33,9 +33,12 @@
 						<span component="topic/scheduled" class="badge badge border border-gray-300 text-body {{{ if !scheduled }}}hidden{{{ end }}}">
 							<i class="fa fa-clock-o"></i> [[topic:scheduled]]
 						</span>
-						<span component="topic/pinned" class="badge badge border border-gray-300 text-body {{{ if (scheduled || !pinned) }}}hidden{{{ end }}}">
-							<i class="fa fa-thumb-tack"></i> {{{ if !pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}
+						{{{ if resolved }}}
+						<span component="topic/resolved" class="badge badge border border-gray-300 text-body">
+							<i class="fa fa-check-circle"></i> Resolved
 						</span>
+						{{{ end }}}
+
 						<span component="topic/locked" class="badge badge border border-gray-300 text-body {{{ if !locked }}}hidden{{{ end }}}">
 							<i class="fa fa-lock"></i> [[topic:locked]]
 						</span>


### PR DESCRIPTION
# What
This PR introduces changes in the front-end repo to display the resolved badge in the UI. 

# Why
Completes the front-end part user story 9. (Back-end part see https://github.com/CMU-313/nodebb-f24-the-turtles/pull/47)

# How
## 1) modify dropdown menu template to add the 'Mark as Resolved' button

<img width="229" alt="Screen Shot 2024-10-03 at 10 01 22" src="https://github.com/user-attachments/assets/783d426e-4e30-40fc-a808-e6cf229db09a">

## 2) modify the topic list template to add the 'Resolved' badge

<img width="281" alt="Screen Shot 2024-10-03 at 10 01 41" src="https://github.com/user-attachments/assets/1a719899-95f7-489f-ab1f-025a52dbc755">

<img width="403" alt="Screen Shot 2024-10-03 at 09 59 37" src="https://github.com/user-attachments/assets/bcbfbe17-ddb0-42f1-83fc-2ea76560e54a">

# Testing
Manually navigate to the pages to see the changes. 

