### PR TITLE
Added translation UI

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -61,6 +61,15 @@
 
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
+
+			{{{if !posts.isEnglish }}}
+		        <div class="sensitive-content-message">
+		        <a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
+		        </div>
+		        <div class="translated-content" style="display:none;">
+		        {posts.translatedContent}
+		        </div>
+	        {{{end}}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## What?
- Added a user interface for post translation, including a "Translate" button that appears for posts.
- When clicked, the button displays the translated content directly under the original post.
- Backend changes: https://github.com/CMU-313/nodebb-f24-the-turtles/pull/62
- Deployed site: [NodeBB Home - Turtles](https://nodebb-team-turtles-awfwbqc8bgbge6ek.canadacentral-01.azurewebsites.net/)

## Why?
This feature allows users to translate non-English posts easily, facilitating communication and understanding across language barriers.

## Testing
Manually tested the functionality by navigating to various posts with non-English content.

### Screenshot
<img width="870" alt="Screenshot 2024-11-10 at 11 10 41 PM" src="https://github.com/user-attachments/assets/3f6fff1a-97f4-4c87-be5d-3ea5d49f5035">
